### PR TITLE
Adding automatic mailing when admitting users

### DIFF
--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -627,8 +627,8 @@ UserController.resetPassword = function(token, password, callback){
 /**
  * [ADMIN ONLY]
  *
- * Admit a user.
- * @param  {String}   userId   User id of the admit
+ * Admit a user and send an automatic confirmation email
+ * @param  {String}   id   User id of the admit
  * @param  {String}   user     User doing the admitting
  * @param  {Function} callback args(err, user)
  */
@@ -648,6 +648,16 @@ UserController.admitUser = function(id, user, callback){
         new: true
       },
       callback);
+
+    //Find the user by the ID and send him an email
+    User.findOne(
+      {_id: id},
+      function(err, user){
+        if (err || !user){
+          return callback(err);
+        }
+      Mailer.sendConfirmationEmail(user.email);
+    });
   });
 };
 

--- a/app/server/services/email.js
+++ b/app/server/services/email.js
@@ -97,7 +97,7 @@ controller.sendVerificationEmail = function(email, token, callback) {
   };
 
   /**
-   * Eamil-verify takes a few template values:
+   * Email-verify takes a few template values:
    * {
    *   verifyUrl: the url that the user must visit to verify their account
    * }
@@ -114,6 +114,38 @@ controller.sendVerificationEmail = function(email, token, callback) {
     }
   });
 
+};
+
+/**
+  confirmationUrl: ROOT_URL + '/confirmation'
+*/
+
+controller.sendConfirmationEmail = function(email, callback) {
+  var options = {
+    to: email,
+    subject: "["+HACKATHON_NAME+"] - You're in."
+  };
+
+  var locals = {
+    title: 'You\'re in.',
+    subtitle: 'Congrats! You\'ve been accepted to ' + HACKATHON_NAME + '!',
+    description: 'Please make sure you confirm your application by clicking the button below. ' +
+      'By not confirming your application, you will not be able to take part in the hackathon.',
+    actionUrl: ROOT_URL + '/confirmation',
+    actionName: 'Confirm Application'
+  };
+
+  sendOne('email-link-action', options, locals, function(err, info) {
+    if (err){
+      console.log(err);
+    }
+    if (info){
+      console.log(info.message);
+    }
+    if (callback){
+      callback(err, info);
+    }
+  });
 };
 
 /**
@@ -139,7 +171,7 @@ controller.sendPasswordResetEmail = function(email, token, callback) {
   };
 
   /**
-   * Eamil-verify takes a few template values:
+   * Email-verify takes a few template values:
    * {
    *   verifyUrl: the url that the user must visit to verify their account
    * }


### PR DESCRIPTION
When admins admit users, the users get specialized emails saying that they have been accepted.
This will let users know that they've been accepted, so they continue their application process.